### PR TITLE
Add status labels to pod resource metrics to enable filtering out evicted pods

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -2,10 +2,12 @@
 
 | Metric name                       | Metric type | Labels/tags                                                   | Status |
 | --------------------------------  | ----------- | ------------------------------------------------------------- | ------ |
+| kube_hpa_labels                   | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_metadata_generation      | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_spec_max_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_spec_min_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_hpa_status_current_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_hpa_status_currentmetrics_average_utilization | Gauge     | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
+| kube_hpa_status_currentmetrics_average_value | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
 | kube_hpa_status_desired_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_labels                   | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -21,6 +21,7 @@ import (
 
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
@@ -48,6 +49,10 @@ func TestHPAStore(t *testing.T) {
         # TYPE kube_hpa_status_condition gauge
         # HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
         # TYPE kube_hpa_labels gauge
+        # HELP kube_hpa_status_currentmetrics_average_value Average metric value observed by the autoscaler.
+        # TYPE kube_hpa_status_currentmetrics_average_value gauge
+        # HELP kube_hpa_status_currentmetrics_average_utilization Average metric utilization observed by the autoscaler.
+        # TYPE kube_hpa_status_currentmetrics_average_utilization gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -77,20 +82,33 @@ func TestHPAStore(t *testing.T) {
 						{
 							Type:   autoscaling.AbleToScale,
 							Status: v1.ConditionTrue,
+							Reason: "reason",
+						},
+					},
+					CurrentMetrics: []autoscaling.MetricStatus{
+						{
+							Type: "Resource",
+							Resource: &autoscaling.ResourceMetricStatus{
+								Name:                      "cpu",
+								CurrentAverageUtilization: new(int32),
+								CurrentAverageValue:       resource.MustParse("10"),
+							},
 						},
 					},
 				},
 			},
 			Want: metadata + `
-                kube_hpa_labels{hpa="hpa1",label_app="foobar",namespace="ns1"} 1
-				kube_hpa_metadata_generation{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_spec_max_replicas{hpa="hpa1",namespace="ns1"} 4
-				kube_hpa_spec_min_replicas{hpa="hpa1",namespace="ns1"} 2
-                kube_hpa_status_condition{condition="false",hpa="hpa1",namespace="ns1",status="AbleToScale"} 0
-                kube_hpa_status_condition{condition="true",hpa="hpa1",namespace="ns1",status="AbleToScale"} 1
-                kube_hpa_status_condition{condition="unknown",hpa="hpa1",namespace="ns1",status="AbleToScale"} 0
-				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
+                            kube_hpa_labels{hpa="hpa1",label_app="foobar",namespace="ns1"} 1
+                            kube_hpa_metadata_generation{hpa="hpa1",namespace="ns1"} 2
+                            kube_hpa_spec_max_replicas{hpa="hpa1",namespace="ns1"} 4
+                            kube_hpa_spec_min_replicas{hpa="hpa1",namespace="ns1"} 2
+                            kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="false"} 0
+                            kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="true"} 1
+                            kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="unknown"} 0
+                            kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
+                            kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
+                            kube_hpa_status_currentmetrics_average_value{hpa="hpa1",namespace="ns1"} 10
+                            kube_hpa_status_currentmetrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
 			`,
 			MetricNames: []string{
 				"kube_hpa_metadata_generation",
@@ -100,6 +118,8 @@ func TestHPAStore(t *testing.T) {
 				"kube_hpa_status_desired_replicas",
 				"kube_hpa_status_condition",
 				"kube_hpa_labels",
+				"kube_hpa_status_currentmetrics_average_value",
+				"kube_hpa_status_currentmetrics_average_utilization",
 			},
 		},
 	}

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -741,7 +741,7 @@ var (
 						switch resourceName {
 						case v1.ResourceCPU:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitCore)},
 								Value:       float64(val.MilliValue()) / 1000,
 							})
 						case v1.ResourceStorage:
@@ -750,25 +750,25 @@ var (
 							fallthrough
 						case v1.ResourceMemory:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 								Value:       float64(val.Value()),
 							})
 						default:
 							if isHugePageResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isAttachableVolumeResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isExtendedResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitInteger)},
 									Value:       float64(val.Value()),
 								})
 							}
@@ -777,7 +777,7 @@ var (
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+					metric.LabelKeys = []string{"container", "node", "resource", "reason", "status", "unit"}
 				}
 
 				return &metric.Family{
@@ -800,7 +800,7 @@ var (
 						case v1.ResourceCPU:
 							ms = append(ms, &metric.Metric{
 								Value:       float64(val.MilliValue()) / 1000,
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitCore)},
 							})
 						case v1.ResourceStorage:
 							fallthrough
@@ -808,26 +808,26 @@ var (
 							fallthrough
 						case v1.ResourceMemory:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 								Value:       float64(val.Value()),
 							})
 						default:
 							if isHugePageResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isAttachableVolumeResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 								})
 							}
 							if isExtendedResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitInteger)},
 								})
 							}
 						}
@@ -835,7 +835,7 @@ var (
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+					metric.LabelKeys = []string{"container", "node", "resource", "reason", "status", "unit"}
 				}
 
 				return &metric.Family{
@@ -858,7 +858,8 @@ var (
 						case v1.ResourceCPU:
 							ms = append(ms, &metric.Metric{
 								Value:       float64(val.MilliValue()) / 1000,
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								LabelKeys:   []string{"container", "node", "reason", "status"},
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitCore)},
 							})
 						case v1.ResourceStorage:
 							fallthrough
@@ -866,26 +867,26 @@ var (
 							fallthrough
 						case v1.ResourceMemory:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 								Value:       float64(val.Value()),
 							})
 						default:
 							if isHugePageResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isAttachableVolumeResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitByte)},
 								})
 							}
 							if isExtendedResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), p.Status.Reason, string(p.Status.Phase), string(constant.UnitInteger)},
 								})
 							}
 						}
@@ -893,7 +894,7 @@ var (
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+					metric.LabelKeys = []string{"container", "node", "resource", "reason", "status", "unit"}
 				}
 
 				return &metric.Family{
@@ -912,8 +913,8 @@ var (
 					req := c.Resources.Requests
 					if cpu, ok := req[v1.ResourceCPU]; ok {
 						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"container", "node"},
-							LabelValues: []string{c.Name, p.Spec.NodeName},
+							LabelKeys:   []string{"container", "node", "reason", "status"},
+							LabelValues: []string{c.Name, p.Spec.NodeName, p.Status.Reason, string(p.Status.Phase)},
 							Value:       float64(cpu.MilliValue()) / 1000,
 						})
 					}
@@ -935,8 +936,8 @@ var (
 					req := c.Resources.Requests
 					if mem, ok := req[v1.ResourceMemory]; ok {
 						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"container", "node"},
-							LabelValues: []string{c.Name, p.Spec.NodeName},
+							LabelKeys:   []string{"container", "node", "reason", "status"},
+							LabelValues: []string{c.Name, p.Spec.NodeName, p.Status.Reason, string(p.Status.Phase)},
 							Value:       float64(mem.Value()),
 						})
 					}
@@ -958,8 +959,8 @@ var (
 					lim := c.Resources.Limits
 					if cpu, ok := lim[v1.ResourceCPU]; ok {
 						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"container", "node"},
-							LabelValues: []string{c.Name, p.Spec.NodeName},
+							LabelKeys:   []string{"container", "node", "reason", "status"},
+							LabelValues: []string{c.Name, p.Spec.NodeName, p.Status.Reason, string(p.Status.Phase)},
 							Value:       float64(cpu.MilliValue()) / 1000,
 						})
 					}
@@ -982,8 +983,8 @@ var (
 
 					if mem, ok := lim[v1.ResourceMemory]; ok {
 						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"container", "node"},
-							LabelValues: []string{c.Name, p.Spec.NodeName},
+							LabelKeys:   []string{"container", "node", "reason", "status"},
+							LabelValues: []string{c.Name, p.Spec.NodeName, p.Status.Reason, string(p.Status.Phase)},
 							Value:       float64(mem.Value()),
 						})
 					}

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1185,6 +1185,10 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 					Name:      "pod1",
 					Namespace: "ns1",
 				},
+				Status: v1.PodStatus{
+					Phase:  "Failed",
+					Reason: "Evicted",
+				},
 				Spec: v1.PodSpec{
 					NodeName: "node1",
 					Containers: []v1.Container{
@@ -1261,33 +1265,33 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				# TYPE kube_pod_container_resource_requests_memory_bytes gauge
 				# TYPE kube_pod_init_container_resource_limits gauge
 				# TYPE kube_pod_init_container_status_last_terminated_reason gauge
-				kube_pod_container_resource_requests_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 0.2
-				kube_pod_container_resource_requests_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 0.3
-				kube_pod_container_resource_requests_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
-				kube_pod_container_resource_requests_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
-				kube_pod_container_resource_limits_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 0.2
-				kube_pod_container_resource_limits_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 0.3
-				kube_pod_container_resource_limits_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
-				kube_pod_container_resource_limits_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
-				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.3
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
-				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 2e+08
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.3
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
-				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 2e+08
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
+				kube_pod_container_resource_limits_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 0.2
+				kube_pod_container_resource_limits_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 0.3
+				kube_pod_container_resource_limits_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 1e+08
+				kube_pod_container_resource_limits_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 2e+08
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="cpu",status="Failed",unit="core"} 0.2
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="ephemeral_storage",status="Failed",unit="byte"} 3e+08
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="memory",status="Failed",unit="byte"} 1e+08
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="nvidia_com_gpu",status="Failed",unit="integer"} 1
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="storage",status="Failed",unit="byte"} 4e+08
+				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="cpu",status="Failed",unit="core"} 0.3
+				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="memory",status="Failed",unit="byte"} 2e+08
+				kube_pod_container_resource_requests_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 0.2
+				kube_pod_container_resource_requests_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 0.3
+				kube_pod_container_resource_requests_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 1e+08
+				kube_pod_container_resource_requests_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",status="Failed"} 2e+08
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="cpu",status="Failed",unit="core"} 0.2
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="ephemeral_storage",status="Failed",unit="byte"} 3e+08
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="memory",status="Failed",unit="byte"} 1e+08
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="nvidia_com_gpu",status="Failed",unit="integer"} 1
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="storage",status="Failed",unit="byte"} 4e+08
+				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="cpu",status="Failed",unit="core"} 0.3
+				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="memory",status="Failed",unit="byte"} 2e+08
+				kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="cpu",status="Failed",unit="core"} 0.2
+				kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="ephemeral_storage",status="Failed",unit="byte"} 3e+08
+				kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="memory",status="Failed",unit="byte"} 1e+08
+				kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="nvidia_com_gpu",status="Failed",unit="integer"} 1
+				kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",reason="Evicted",resource="storage",status="Failed",unit="byte"} 4e+08
 		`,
 			MetricNames: []string{
 				"kube_pod_container_resource_requests_cpu_cores",
@@ -1373,24 +1377,24 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				# TYPE kube_pod_container_resource_requests_cpu_cores gauge
 				# TYPE kube_pod_container_resource_requests_memory_bytes gauge
 				# TYPE kube_pod_init_container_resource_limits gauge
-				kube_pod_container_resource_requests_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 0.4
-				kube_pod_container_resource_requests_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 0.5
-				kube_pod_container_resource_requests_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
-				kube_pod_container_resource_requests_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
-				kube_pod_container_resource_limits_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 0.4
-				kube_pod_container_resource_limits_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 0.5
-				kube_pod_container_resource_limits_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
-				kube_pod_container_resource_limits_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
-				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
-				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.5
-				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
-				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 4e+08
-				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
-				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.5
-				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
-				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 4e+08
-                kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
-                kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
+				kube_pod_container_resource_limits_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 0.4
+				kube_pod_container_resource_limits_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 0.5
+				kube_pod_container_resource_limits_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 3e+08
+				kube_pod_container_resource_limits_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 4e+08
+				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",resource="cpu",status="",unit="core"} 0.4
+				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",resource="memory",status="",unit="byte"} 3e+08
+				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",resource="cpu",status="",unit="core"} 0.5
+				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",resource="memory",status="",unit="byte"} 4e+08
+				kube_pod_container_resource_requests_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 0.4
+				kube_pod_container_resource_requests_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 0.5
+				kube_pod_container_resource_requests_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 3e+08
+				kube_pod_container_resource_requests_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",status=""} 4e+08
+				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",resource="cpu",status="",unit="core"} 0.4
+				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",reason="",resource="memory",status="",unit="byte"} 3e+08
+				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",resource="cpu",status="",unit="core"} 0.5
+				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",reason="",resource="memory",status="",unit="byte"} 4e+08
+				kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",reason="",resource="cpu",status="",unit="core"} 0.4
+				kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",reason="",resource="memory",status="",unit="byte"} 3e+08
 		`,
 			MetricNames: []string{
 				"kube_pod_container_resource_requests_cpu_cores",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Working on building cluster resource utilization dashboard and would like to use k-s-m as the source of truth to pull container requests from and from there calculate requests per node as this is not exposed by k8s on the node level. I need to add the Status and Reason to the requests/limits stats though so that I can filter out "Evicted" or otherwise terminated pods. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

